### PR TITLE
Add GH Action to check livelyness

### DIFF
--- a/.github/workflows/checkLivelyness.sh
+++ b/.github/workflows/checkLivelyness.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+CNT=0
+ITER=$1
+SLEEP=$2
+NUMBLOCKS=$3
+NODEADDR=$4
+
+if [ -z "$1" ]; then
+  echo "Invalid argument: missing number of iterations"
+  echo "sh test_localnet_liveness.sh <iterations> <sleep> <num-blocks> <node-address>"
+  exit 1
+fi
+
+if [ -z "$2" ]; then
+  echo "Invalid argument: missing sleep duration"
+  echo "sh test_localnet_liveness.sh <iterations> <sleep> <num-blocks> <node-address>"
+  exit 1
+fi
+
+if [ -z "$3" ]; then
+  echo "Invalid argument: missing number of blocks"
+  echo "sh test_localnet_liveness.sh <iterations> <sleep> <num-blocks> <node-address>"
+  exit 1
+fi
+
+if [ -z "$4" ]; then
+  echo "Invalid argument: missing node address"
+  echo "sh test_localnet_liveness.sh <iterations> <sleep> <num-blocks> <node-address>"
+  exit 1
+fi
+
+docker_containers=($(docker ps -q -f name=berad --format='{{.Names}}'))
+
+while [ ${CNT} -lt $ITER ]; do
+  curr_block=$(curl -s $NODEADDR:26657/status | jq -r '.result.sync_info.latest_block_height')
+
+  if [ ! -z ${curr_block} ]; then
+    echo "Current block: ${curr_block}"
+  fi
+
+  if [ ! -z ${curr_block} ] && [ ${curr_block} -gt ${NUMBLOCKS} ]; then
+    echo "Success: number of blocks reached"
+    exit 0
+  fi
+
+  sleep $SLEEP
+done
+
+echo "Failed: timeout reached"
+exit 1

--- a/.github/workflows/livelyness.yaml
+++ b/.github/workflows/livelyness.yaml
@@ -1,0 +1,26 @@
+name: Livelyness Check
+on: 
+  pull_request:
+  push:
+    branches: main
+
+jobs:
+  check-livelyness:
+    name: Check Livelyness
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: docker-practice/actions-setup-docker@master
+        if: ${{ matrix.os == 'macos-latest' }}
+
+      - name: Bring up berachain
+        run: |
+          make start
+      - name: check
+        run: |
+          ./checkLivelyness.sh 10 10 10 http://localhost
+        working-directory: .github/workflows


### PR DESCRIPTION
Fixes #2 

Runs Linux x64_86 and macOS x64_86. As best I can tell, ARM variants of the above are only available as self-hosted runners.

Another caveat is that the macOS hosted runner does not come with Docker preinstalled, this _significantly_ increases the execution time of the macOS runner from ~25s to around 10 minutes. Leveraging a preexisting action to ensure Docker is configured correctly for the runner as it seems to be a delicate process to do so. 

Will run on all PRs and pushes to `main`. 